### PR TITLE
chore(deps): bump aws-sdk to v2.1263.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -327,9 +327,9 @@ available-typed-arrays@^1.0.5:
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sdk@^2.1258.0:
-  version "2.1262.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1262.0.tgz#434980d0bee9e67c4764a532577f3a2a54b1c38a"
-  integrity sha512-XbaK/XUIxwLEBnHANhJ0RTZtiU288lFRj5FllSihQ5Kb0fibKyW8kJFPsY+NzzDezLH5D3WdGbTKb9fycn5TbA==
+  version "2.1263.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1263.0.tgz#898c01ceb5c5c56bcb25d41a20f845d7722d3435"
+  integrity sha512-luYVrKPZ363LYU689XS79xW3fDw1SEQH46B9scWlQ1W/36d0wrJRd+FmnnNiSV2XR1VDfDicMbEbI/rqCD8pkw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Verified that "Request is missing Authentication Token" error is not thrown after bumping `aws-sdk` to `v2.1263.0` 

```
$ yarn

$ yarn deploy
Deploying serverless-aws-test to stage dev (eu-central-1)

✔ Service deployed to stack serverless-aws-test-dev (152s)

functions:
  test: serverless-aws-test-dev-test (36 MB)
```